### PR TITLE
add max-width style along with the width

### DIFF
--- a/js/flex2html.js
+++ b/js/flex2html.js
@@ -176,7 +176,7 @@ function box_object(json) {
       exmgn = (margin) ? 'ExMgnT' + upperalldigit(margin) : ''
    }
    if(width && width !== '') {
-      style += `width:${width};`
+      style += `width:${width}; max-width:${width};`
    }
    if(height && height !== '') {
       style += `height:${height};`


### PR DESCRIPTION
The `width` attribute alone seems to be overridden by the `flex: 1 0 0` attribute.
It means that even if I put `width: 56px` in the box, I may ended up having the flex 1 box with 140px total width.

So adding the `max-width` here will force the width to be exactly 56px.