### PR TITLE
fix hero and header position of bubble_struct

### DIFF
--- a/js/flex2html.js
+++ b/js/flex2html.js
@@ -690,7 +690,7 @@ function bubble_struc(json) {
    direction = (!direction || direction == '') ? 'ltr' : direction
    size = upper2digit(size)
 
-   return `<div class="lyItem Ly${size}"><div class="T1 fx${direction.toUpperCase()}" dir="${direction}"><!-- hero --><!-- header --><!-- body --><!-- footer --></div></div>`
+   return `<div class="lyItem Ly${size}"><div class="T1 fx${direction.toUpperCase()}" dir="${direction}"><!-- header --><!-- hero --><!-- body --><!-- footer --></div></div>`
 }
 function hero_struc(json) {
    let {styles} = json


### PR DESCRIPTION
- fixed the `bubble_struc()` in` js/flex2html.js` by switching the hero and header's position